### PR TITLE
Fix for missing navigation bar, broken Settings menus

### DIFF
--- a/resource/layout/subpaneloptionsbrowser.layout
+++ b/resource/layout/subpaneloptionsbrowser.layout
@@ -10,9 +10,7 @@
 		
 		ClientBrowserAuthHomePage { ControlName=CheckButton fieldName="ClientBrowserAuthHomePage" }
 
-		ClearWebCacheButton { ControlName=Button labelText="#Steam_SettingsBrowserClearWebCache" 	command=ClearWebCache }
-		ClearAllCookiesButton { ControlName=Button labelText="#Steam_SettingsBrowserClearAllCookies" 	command=ClearCookies }
-
+		ClearAllBrowserDataButton { ControlName=Button labelText="#Steam_SettingsBrowserDeleteAllData" 	command=ClearAllBrowserData }
 	}
 	
 	colors
@@ -39,11 +37,11 @@
 		place { start=DescriptionLabel controls=OverlayHomePageLabel dir=down margin-top=10 width=200 }
 		
 		place { start=OverlayHomePageLabel controls=OverlayHomePage dir=down margin-top=4 width=240 }
-		place { start=OverlayHomePage controls=ClientBrowserAuthHomePage dir=down margin-top=4 height=26 }
+		place { start=OverlayHomePage controls=ClientBrowserAuthHomePage dir=down margin-top=8 height=26 }
 		
-		place { start=ClientBrowserAuthHomePage controls=Divider1 dir=down region=bottom width=max margin-top=6 margin-right=10 }
+		place { start=ClientBrowserAuthHomePage controls=Divider1 dir=down region=bottom width=max margin-top=8 margin-right=10 }
 		
-		place { controls=ClearWebCacheButton,ClearAllCookiesButton start=Divider1 dir=down height=20 region=bottom margin-top=10 height=20 spacing=4 }
+		place { start=Divider1 controls=ClearAllBrowserDataButton height=20 width=240 region=bottom dir=down margin-top=15 }
 		
 	}
 }

--- a/resource/layout/subpaneloptionscontroller.layout
+++ b/resource/layout/subpaneloptionscontroller.layout
@@ -13,6 +13,7 @@
 		GuideConfigButton { ControlName=Button labelText="#Steam_SettingsControllerGuideConfig" 	command=EditGuideConfig }				
 		Divider2 { ControlName=Divider	}
 		DisableNotificationsCheckbox { controlname=checkbutton labeltext="#Steam_SteamInputDisableNotifications"}
+		DisableDualSenseUpdatesCheckbox { controlname=checkbutton labeltext="#Steam_SteamInputDisableDualSenseUpdates"}
 	}
 	
 	colors
@@ -45,5 +46,6 @@
 		place { start=DescriptionBindingLabel controls="BigPictureConfigButton,DesktopConfigButton,GuideConfigButton" height=20 width=240 dir=down spacing=4 }	
 		place { start=GuideConfigButton controls=Divider2 region=top dir=down margin-top=7 width=max}		
 		place { start=Divider2 controls=DisableNotificationsCheckbox height=18 width=max region=top dir=down margin-top=5 }
+		place { start=DisableNotificationsCheckbox controls=DisableDualSenseUpdatesCheckbox height=18 width=max region=top dir=down }
 	}
 }

--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -2,30 +2,24 @@
 {
 	controls
 	{
-		RegionLabel {	controlname=label	labeltext=#Steam_RegionLabel	style=highlight 	}
-		LibrariesLabel {	controlname=label	labeltext=#Steam_LibrariesLabel	style=highlight }
-		RestrictionsLabel {	controlname=label	labeltext=#Steam_DownloadRestrictionsLabel	style=highlight 	}
-		RegionInfoLabel {	controlname=label labeltext=#Steam_RegionInfo wrap=1		}
+		RegionLabel { controlname=label labeltext=#Steam_RegionLabel style=highlight }
+		DownloadRegionCombo	{ controlname=combobox editable="0"	}
+		RegionInfoLabel { controlname=label labeltext=#Steam_RegionInfo wrap=1 }
+		
+		RestrictionsLabel {	controlname=label	labeltext=#Steam_DownloadRestrictionsLabel	style=highlight }
+		
 		ManageInstalledappsLabel { controlname=label labeltext=#SteamUI_ContentMgr_ManageInstalledAppsInfo }
 		FlushDownloadConfigLabel { controlname=label labeltext=#SteamUI_ContentMgr_FlushDownloadConfigInfo tooltiptext=#SteamUI_ContentMgr_FlushDownloadConfigTip }
 				
 		ThrottleCheckbox { controlname=checkbutton  labeltext=#Steam_ThrottleRatesLabel }
-		ThrottleRateCurrent { controlname=label }
-		ThrottleRateEditLabel { controlname=label labeltext=#SteamUI_ThrottleEditLabel }
+		
 		ThrottleRateEdit { controlname=textentry }
 		ThrottleRateEditSuffix { controlname=label }
-		ThrottleRateApply 
-		{ 
-			controlname=button 
-			labeltext = #SteamUI_ThrottleApplyChange
-			command=ChangeThrottleValue
-		}
-		DownloadRegionCombo
-		{
-			controlname=combobox
-			editable="0"
-		}
 		
+		PeerContentLabel { controlname=label labeltext=#Steam_PeerContentTitle style=highlight group="PeerContentEnabled"}
+		PeerContentCombo	{ controlname=combobox editable="0"	group="PeerContentEnabled"}
+		PeerContentInfoLabel { controlname=label labeltext=#Steam_PeerContentInfo wrap=1 group="PeerContentEnabled" }
+				
 		ManageInstalledApps
 		{
 			controlname=button
@@ -39,23 +33,21 @@
 			labeltext = #SteamUI_ContentMgr_FlushDownloadConfig
 			command=FlushContentConfig
 		}
-
+		
 		AutoUpdateTimeRestrictCheckbox { controlname=checkbutton labeltext=#Steam_AutoUpdateTimeRestrictionLabel }
 		AutoUpdateTimeRestrictEndLabel { controlname=label labeltext=#Steam_AutoUpdateTimeRestrictionEnd style=padded }
 		AutoUpdateTimeRestrictStart { controlname=combobox }
 		AutoUpdateTimeRestrictEnd { controlname=combobox }
 		AllowDownloadsDuringGameplayCheckbox { controlname=checkbutton labeltext=#Steam_AllowDownloadsDuringGameplay tooltiptext=#Steam_AllowDownloadsDuringGameplayDetails}
-		ThrottleDownloadsWhileStreamingCheckbox { controlname=checkbutton labeltext=#Steam_ThrottleDownloadsWhileStreaming }
+		ThrottleDownloadsWhileStreamingCheckbox { controlname=checkbutton labeltext=#Steam_ThrottleDownloadsWhileStreaming tooltiptext=#Steam_ThrottleDownloadsWhileStreamingDetails }
 		DownloadRatesInBitsCheckbox { controlname=checkbutton labeltext=#Steam_DownloadRatesInBits }
+				
 		
-		Divider1 { ControlName=Divider	}				
-		Divider2 { ControlName=Divider	}				
-		Divider3 { ControlName=Divider	}				
+		Divider1 { ControlName=Divider }
+		Divider2 { ControlName=Divider }				
+		Divider3 { ControlName=Divider group="PeerContentEnabled" }	
+		
 	}
-	
-	colors
-	{
-	}	
 	
 	styles
 	{
@@ -73,42 +65,44 @@
 	layout
 	{
 		region { name=box margin-top=3 margin-bottom=20 margin-left=10 margin-right=10 width=max height=max }
-		
-		place { controls="ManageInstalledappsLabel" region=box margin-top=3 width=max }		
-		place { controls="ManageInstalledApps" region=box start=ManageInstalledappsLabel height=20 margin-top=6 dir=down }
-		
-		place { controls="Divider1" region=box start=ManageInstalledApps dir=down margin-top=9 width=max }
-		
-		place { controls="RegionLabel" region=box start=Divider1 dir=down margin-top=5 }
-		place { controls="DownloadRegionCombo" region=box start=RegionLabel margin-top=6 height=21 width=200  dir=down }
+					
+		place { controls="RegionLabel" region=box margin-top=5 dir=down }
+		place { controls="DownloadRegionCombo" region=box start=RegionLabel margin-top=6 height=21 width=200 dir=down }
 		place { controls="RegionInfoLabel" region=box start=DownloadRegionCombo margin-top=5 width=max dir=down }
 	
-		place { controls="Divider2" region=box start=RegionInfoLabel dir=down width=max margin-top=7 }
+		place { controls="Divider1" region=box start=RegionInfoLabel dir=down width=max margin-top=7 }
 				
-		place { controls="RestrictionsLabel" region=box start=Divider2 dir=down margin-top=7 }
+		place { controls="RestrictionsLabel" region=box start=Divider1 dir=down margin-top=7 }
 		
-		place { controls="AutoUpdateTimeRestrictCheckbox" region=box start=RestrictionsLabel y=1 dir=down  }
-		place { controls="AutoUpdateTimeRestrictStart" region=box start=AutoUpdateTimeRestrictCheckbox y=2 dir=down margin-top=4 }
-		place { controls="AutoUpdateTimeRestrictEndLabel" region=box start=AutoUpdateTimeRestrictStart y=-2 dir=right margin-left=10 }
-		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel y=2 dir=right margin-left=4 width=77 height=20 }
+		place { controls="AutoUpdateTimeRestrictCheckbox" region=box start=RestrictionsLabel height=18 dir=down margin-top=5 }
+		place { controls="AutoUpdateTimeRestrictStart" region=box start=AutoUpdateTimeRestrictCheckbox height=20 dir=right margin-top=1 width=78 margin-left=5 }
+		place { controls="AutoUpdateTimeRestrictEndLabel" region=box start=AutoUpdateTimeRestrictStart dir=right margin-left=5 }
+		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel height=20 dir=right margin-left=5 width=78 }
 		
-		place { controls="ThrottleCheckbox" region=box start=RestrictionsLabel dir=down margin-top=6 margin-left=260 height=18 }
-		place { controls="ThrottleRateCurrent" region=box start=ThrottleCheckbox dir=down width=235 margin-top=6 }
-		place { controls="ThrottleRateEditLabel" region=box start=ThrottleRateCurrent dir=down width=175 height=20 margin-top=5 }
-		place { controls="ThrottleRateEdit" region=box start=ThrottleRateEditLabel dir=down width=125 height=20 }
-		place { controls="ThrottleRateEditSuffix" region=box start=ThrottleRateEdit dir=right margin-left=4 margin-top=3 }
-		place { controls="ThrottleRateApply" region=box start=ThrottleRateEdit dir=down width=70 height=20 margin-top=4 }
-		
-		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start="AutoUpdateTimeRestrictStart" height=18 dir=down margin-top=10 }
+		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictCheckbox height=18 dir=down }
 		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayCheckbox height=18 dir=down }
 		place { controls="DownloadRatesInBitsCheckbox" region=box start=ThrottleDownloadsWhileStreamingCheckbox height=18 dir=down }
 		
-		place { controls="Divider3" region=box start=DownloadRatesInBitsCheckbox dir=down width=max margin-top=11 }
+		place { controls="ThrottleCheckbox" region=box start=DownloadRatesInBitsCheckbox height=18 dir=down  }
+		place { controls="ThrottleRateEdit" region=box start=ThrottleCheckbox dir=right width=80 height=20 }
+		place { controls="ThrottleRateEditSuffix" region=box start=ThrottleRateEdit dir=right margin-left=4 margin-top=3 }
 		
-		place { controls="FlushDownloadConfig" region=box start=Divider3 margin-top=10 width=200 height=20 dir=down }
+		place { controls="Divider2" region=box start=ThrottleCheckbox dir=down width=max margin-top=10 }
+		
+		place { controls="ManageInstalledApps" region=box start=Divider2 margin-top=10 width=200 height=20 dir=down }
+		place { controls="ManageInstalledappsLabel" region=box start=ManageInstalledApps margin-top=5 width=max dir=down }		
+		
+		place { controls="FlushDownloadConfig" region=box start=ManageInstalledappsLabel margin-top=15 width=200 height=20 dir=down }
 		place { controls="FlushDownloadConfigLabel" region=box start=FlushDownloadConfig margin-top=5 width=max dir=down }
+		
+		place { controls="Divider3" region=box start=FlushDownloadConfigLabel dir=down width=max margin-top=10 }
+		
+		place { controls="PeerContentLabel" region=box start=Divider3 dir=down margin-top=10 width=max }
+		place { controls="PeerContentCombo" region=box start=PeerContentLabel dir=down margin-top=10 width=235 }
+		place { controls="PeerContentInfoLabel" region=box start=PeerContentCombo dir=down margin-top=10 width=max }
+		
+		
 
 
-		place { controls="LibrariesLabel" width=0 }
 	}
 }

--- a/resource/layout/uinavigatorpanel.layout
+++ b/resource/layout/uinavigatorpanel.layout
@@ -868,27 +868,27 @@
 
 		place [$OSX] { control="label_library_filters" align=left y=23 height=20 spacing=3 x=13 }
 
- 	  	place { control=emailreminderbar margin-top=40 margin-left=0 margin-right=0 width=max height=32 }
- 	  	place { control=phonereminderbar start="emailreminderbar" margin-left=0 margin-right=0 width=max height=48 dir=down }
+ 	  	place { control=LibraryAnchor margin-top=40 margin-left=0 margin-right=0 width=max height=32 }
+ 	  	place { control=LibraryAnchor start="LibraryAnchor" margin-left=0 margin-right=0 width=max height=48 dir=down }
 
 		place [!$OSX] { control="label_library_show,label_library_zoom,label_zoom_separator,label_library_view" x=99999 y=0 height=0 }
 		 place [$OSX] { control="label_library_show,label_library_zoom,label_zoom_separator,label_library_view" x=99999 height=0 width=0 }
 
 		// content pages
-		place { control=DownloadsPage 			width=max height=max margin-top=0 margin-left=2 margin-right=1  margin-bottom=3 start=phonereminderbar dir=down }
-		place { control=ScreenshotsPage 		width=max height=max margin-top=0 margin-left=0 margin-right=0  margin-bottom=0 start=phonereminderbar dir=down }
-		place { control=GamesPage_List 			width=max height=max margin-top=0 margin-left=1 margin-right=0  margin-bottom=0 start=phonereminderbar dir=down }
-		place { control=GamesPage_Details 		width=max height=max margin-top=0 margin-left=0 margin-right=0  margin-bottom=0 start=phonereminderbar dir=down }
-		place { control=GamesPage_Grid 			width=max height=max margin-top=0 margin-left=2 margin-right=1  margin-bottom=3 start=phonereminderbar dir=down }
-		place { control=WebPanel 				width=max height=max margin-top=0 margin-left=2 margin-right=1  margin-bottom=3 start=phonereminderbar dir=down }
-		place { control=BroadcastPage			width=max height=max margin-top=0 margin-left=0 margin-right=9  margin-bottom=21 start=phonereminderbar dir=down }
+		place { control=DownloadsPage 			width=max height=max margin-top=0 margin-left=2 margin-right=1  margin-bottom=3 start=LibraryAnchor dir=down }
+		place { control=ScreenshotsPage 		width=max height=max margin-top=0 margin-left=0 margin-right=0  margin-bottom=0 start=LibraryAnchor dir=down }
+		place { control=GamesPage_List 			width=max height=max margin-top=0 margin-left=1 margin-right=0  margin-bottom=0 start=LibraryAnchor dir=down }
+		place { control=GamesPage_Details 		width=max height=max margin-top=0 margin-left=0 margin-right=0  margin-bottom=0 start=LibraryAnchor dir=down }
+		place { control=GamesPage_Grid 			width=max height=max margin-top=0 margin-left=2 margin-right=1  margin-bottom=3 start=LibraryAnchor dir=down }
+		place { control=WebPanel 				width=max height=max margin-top=0 margin-left=2 margin-right=1  margin-bottom=3 start=LibraryAnchor dir=down }
+		place { control=BroadcastPage			width=max height=max margin-top=0 margin-left=0 margin-right=9  margin-bottom=21 start=LibraryAnchor dir=down }
 		place { control=BroadcastPageMin		width=298 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=26 dir=down align=bottom-right }
 		place { control=BroadcastPageMinHoriz	width=298 height=168 margin-top=0 margin-left=0 margin-right=30 margin-bottom=40 dir=down align=bottom-right }
-		place { control=MusicPage_Details 		width=max height=max margin-top=0 margin-left=2 margin-right=3  margin-bottom=3 start=phonereminderbar dir=down }
-		place { control=ConsolePage 			width=max height=max margin-top=0 margin-left=0 margin-right=0  margin-bottom=0 start=phonereminderbar dir=down }
-		place { control=NewLibraryPage		width=max height=max margin-top=0 margin-left=0 margin-right=9 margin-bottom=21 start=phonereminderbar dir=down }
+		place { control=MusicPage_Details 		width=max height=max margin-top=0 margin-left=2 margin-right=3  margin-bottom=3 start=LibraryAnchor dir=down }
+		place { control=ConsolePage 			width=max height=max margin-top=0 margin-left=0 margin-right=0  margin-bottom=0 start=LibraryAnchor dir=down }
+		place { control=NewLibraryPage		width=max height=max margin-top=0 margin-left=0 margin-right=0 margin-bottom=0 start=LibraryAnchor dir=down }
 
-		place { control=MediaPage 				width=max height=max margin-top=1 margin-left=0 margin-right=28 margin-bottom=0 start=phonereminderbar dir=down }
-		place { control=ToolsPage 				width=max height=max margin-top=1 margin-left=2 margin-right=1  margin-bottom=1 start=phonereminderbar dir=down }
+		place { control=MediaPage 				width=max height=max margin-top=1 margin-left=0 margin-right=28 margin-bottom=0 start=LibraryAnchor dir=down }
+		place { control=ToolsPage 				width=max height=max margin-top=1 margin-left=2 margin-right=1  margin-bottom=1 start=LibraryAnchor dir=down }
 	}
 }

--- a/resource/layout/uinavigatorpanel.layout
+++ b/resource/layout/uinavigatorpanel.layout
@@ -857,7 +857,7 @@
 		place { control="library_filters_details,library_filters_list,library_filters_grid," align=left start="library_filters" dir=right height=20 spacing=4 margin-left=12 width=20 }
 		
 		place { control=URLAnchor align=left y=54 height=28 width=max }
-		place { control=LibraryAnchor height=28 width=max start=URLAnchor dir=down }
+		place { control=LibraryAnchor margin-top=40 margin-left=0 margin-right=0 width=max height=32 }
 
  		place [!$OSX] { control="library_music_menu" height=20 start="library_filters" dir=right margin-left=4 spacing=2 }
  		place [!$OSX] { control="library_music_add_button" height=20 start="library_music_menu" dir=right y=1 x=4 }
@@ -867,9 +867,6 @@
 		 place [$OSX] { control="library_zoom" align=left start="library_filters_grid" y=0 margin-left=12 height=18 }
 
 		place [$OSX] { control="label_library_filters" align=left y=23 height=20 spacing=3 x=13 }
-
- 	  	place { control=LibraryAnchor margin-top=40 margin-left=0 margin-right=0 width=max height=32 }
- 	  	place { control=LibraryAnchor start="LibraryAnchor" margin-left=0 margin-right=0 width=max height=48 dir=down }
 
 		place [!$OSX] { control="label_library_show,label_library_zoom,label_zoom_separator,label_library_view" x=99999 y=0 height=0 }
 		 place [$OSX] { control="label_library_show,label_library_zoom,label_zoom_separator,label_library_view" x=99999 height=0 width=0 }


### PR DESCRIPTION
Quick fix for the missing navigation bar after the latest update (#50 and #51). Also removed empty space below and on the right side of Library.

Additional fixes for broken Setting menus - it's not perfect but some important settings are now usable unlike before. The [subpaneloptionsdownloads.layout](https://github.com/badanka/Compact/pull/52/commits/da98ab378b8807f4398b6a86f28ba76520d20aca) file was several updates behind so I used original Steam layout file and edited that. 

Before:
![downloads-before](https://user-images.githubusercontent.com/90148655/217293568-232f3215-349a-4963-90c5-fe27b01cb1af.png)

After:
![downloads-after](https://user-images.githubusercontent.com/90148655/217293587-3e6d83a7-957b-4026-af5f-8bae19772040.png)
